### PR TITLE
Zero-length xattr bugfix

### DIFF
--- a/utils.c
+++ b/utils.c
@@ -109,6 +109,9 @@ binary_print(const char *s, ssize_t len)
 void
 xfwrite(const void *ptr, size_t size, FILE *stream)
 {
+	if (size == 0) {
+		return;
+	}
 	if (fwrite(ptr, size, 1, stream) != 1) {
 		msg(MSG_CRITICAL, "Failed to write to file: %s\n",
 		    strerror(errno));


### PR DESCRIPTION
This fixes https://bugs.launchpad.net/ubuntu/+source/metastore/+bug/937306 . Your metastore repository seems prominent in Google and seems to be collecting bugfixes while the original author's seems static, so perhaps people will look here first for fixes.
