### PR TITLE
Add support for deleting directories with -a -E

### DIFF
--- a/metastore.1
+++ b/metastore.1
@@ -1,4 +1,4 @@
-.TH metastore "1" "February 2012"
+.TH metastore "9" "February 2015"
 .\"
 .SH NAME
 metastore \- stores and restores filesystem metadata
@@ -46,7 +46,11 @@ Causes metastore to also take mtime into account for the compare or apply action
 Also attempts to recreate missing empty directories. May be useful where
 empty directories are not tracked (e.g. by git or cvs).
 Only works in combination with the \fBapply\fR option.
-This is currently an experimental feature.
+.TP
+.B -E, --remove-empty-dirs
+Also attempts to remove empty directories missing from the metadata. May be
+useful where empty directories are not tracked (e.g. by git or cvs).  Only
+works in combination with the \fBapply\fR option.
 .TP
 .B \-g, \-\-git
 Prevents metastore from omitting .git directories.

--- a/settings.h
+++ b/settings.h
@@ -22,10 +22,11 @@
 
 /* Data structure to hold metastore settings */
 struct metasettings {
-	char *metafile;    /* path to the file containing the metadata */
-	bool do_mtime;     /* should mtimes be corrected? */
-	bool do_emptydirs; /* should empty dirs be recreated? */
-	bool do_git;       /* should .git dirs be processed? */
+	char *metafile;          /* path to the file containing the metadata */
+	bool do_mtime;           /* should mtimes be corrected? */
+	bool do_emptydirs;       /* should empty dirs be recreated? */
+	bool do_removeemptydirs; /* should new empty dirs be removed? */
+	bool do_git;             /* should .git dirs be processed? */
 };
 
 /* Convenient typedef for immutable settings */


### PR DESCRIPTION
github's default title leave too much to the imagination. This should have been titled Add support for deleting directories with -a -E. This fixes (#10).