### PR TITLE
Use /bin/sh as the shell for example scripts instead of bash

### DIFF
--- a/examples/git-metapull
+++ b/examples/git-metapull
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # This script can be used instead of git-pull when updating a remote
 # repo to make sure the metadata matches what is stored in the repo.

--- a/examples/pre-commit
+++ b/examples/pre-commit
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 #
 # An example hook script to store metadata information using
 # metastore on each commit.


### PR DESCRIPTION
There aren't any bashisms in the scripts so there's no reason to
be so specific.