### PR TITLE
Officially ceding maintainership of metastore to Przemyslaw Pawelczyk.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -2,7 +2,7 @@ Original creator of metastore is:
 
 	David Härdeman                                   <david@hardeman.nu>
 
-Current maintainer of unofficial metastore continuation is:
+Current maintainer is:
 
 	Przemysław Pawełczyk                             <przemoc@gmail.com>
 

--- a/README
+++ b/README
@@ -13,10 +13,6 @@ tree and make sure that "everything" (e.g. xattrs, mtime, owner, group)
 is stored along with the files.
 
 
-This metastore is unofficial continuation of the original metastore
-application created by David Härdeman (who no longer maintains it).
-
-
 Stored metadata
 ---------------
 


### PR DESCRIPTION
Signed-off-by: David Härdeman <david@hardeman.nu>