### PR TITLE
Implemented a tar-like "--one-file-system" option for metastore

### DIFF
--- a/src/metaentry.h
+++ b/src/metaentry.h
@@ -57,7 +57,7 @@ struct metaentry *mentry_create(const char *path);
 
 /* Recurses opath and adds metadata entries to the metaentry list */
 void mentries_recurse_path(const char *opath, struct metahash **mhash,
-                           msettings *st);
+                           struct metasettings *st);
 
 /* Stores a metaentry list to a file */
 void mentries_tofile(const struct metahash *mhash, const char *path);

--- a/src/metastore.c
+++ b/src/metastore.c
@@ -34,6 +34,7 @@
 #include "utils.h"
 #include "metaentry.h"
 
+
 /* metastore settings */
 static struct metasettings settings = {
 	.metafile = METAFILE,
@@ -41,6 +42,8 @@ static struct metasettings settings = {
 	.do_emptydirs = false,
 	.do_removeemptydirs = false,
 	.do_git = false,
+	.restrict_to_fs = 0,
+	.device_id = 0,
 };
 
 /* Used to create lists of dirs / other files which are missing in the fs */
@@ -429,6 +432,7 @@ usage(const char *arg0, const char *message)
 "  -e, --empty-dirs         Recreate missing empty directories\n"
 "  -E, --remove-empty-dirs  Remove extra empty directories\n"
 "  -g, --git                Do not omit .git directories\n"
+"      --one-file-system    Stay within the root folder's file system\n"
 "  -f, --file=FILE          Set metadata file (" METAFILE " by default)\n"
 	    );
 
@@ -449,6 +453,7 @@ static struct option long_options[] = {
 	{ "empty-dirs",        no_argument,       NULL, 'e' },
 	{ "remove-empty-dirs", no_argument,       NULL, 'E' },
 	{ "git",               no_argument,       NULL, 'g' },
+	{ "one-file-system",   no_argument,       &settings.restrict_to_fs, (int)CommandLineOption_RestrictFS },
 	{ "file",              required_argument, NULL, 'f' },
 	{ NULL, 0, NULL, 0 }
 };
@@ -485,7 +490,9 @@ main(int argc, char **argv)
 			                              break;
 		case 'g': /* git */               settings.do_git = true;        break;
 		case 'f': /* file */              settings.metafile = optarg;    break;
+		case   0: /* flag set */    break;
 		default:
+			printf("%d %d\n", c, settings.restrict_to_fs);
 			usage(argv[0], "unknown option");
 		}
 	}

--- a/src/settings.h
+++ b/src/settings.h
@@ -22,14 +22,27 @@
 
 /* Data structure to hold metastore settings */
 struct metasettings {
-	char *metafile;          /* path to the file containing the metadata */
-	bool do_mtime;           /* should mtimes be corrected? */
-	bool do_emptydirs;       /* should empty dirs be recreated? */
-	bool do_removeemptydirs; /* should new empty dirs be removed? */
-	bool do_git;             /* should .git dirs be processed? */
+	char *metafile;          /**< path to the file containing the metadata */
+	bool do_mtime;           /**< should mtimes be corrected? */
+	bool do_emptydirs;       /**< should empty dirs be recreated? */
+	bool do_removeemptydirs; /**< should new empty dirs be removed? */
+	bool do_git;             /**< should .git dirs be processed? */
+	int  restrict_to_fs;     /**< should processing only be done within this FS? */
+	unsigned long long int device_id;      /**< device id storage if do_one_fs */
 };
 
 /* Convenient typedef for immutable settings */
 typedef const struct metasettings msettings;
+
+
+/**
+ * enum for identifying additional command line arguments without single character [-x] option
+ * respective flags (e.g. settings.restrict_to_fs) will be set to the
+ * corresponding value
+ */
+enum _CommandLineOption {
+  CommandLineOption_None = 0,		/**< option not set */
+  CommandLineOption_RestrictFS,		/**< value for --one-file-system*/
+};
 
 #endif /* SETTINGS_H */


### PR DESCRIPTION
Added a --one-file-system option to stay within the current file system when storing/comparing/applying metadata.
Checks whether the dev_id of the file/dir is the same as the root folder, analog to the same flag in tar.

    --one-file-system    Stay within the root folder's file system