### PR TITLE
Add support for OpenBSD.

### DIFF
--- a/src/metaentry.c
+++ b/src/metaentry.c
@@ -24,7 +24,9 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#ifndef __OpenBSD__
 #include <sys/xattr.h>
+#endif
 #include <limits.h>
 #include <dirent.h>
 #include <sys/mman.h>
@@ -44,6 +46,7 @@
 #include "utils.h"
 
 /* Free's a metaentry and all its parameters */
+#ifndef __OpenBSD__
 static void
 mentry_free(struct metaentry *m)
 {
@@ -67,6 +70,7 @@ mentry_free(struct metaentry *m)
 
 	free(m);
 }
+#endif
 
 /* Allocates an empty metahash table */
 static struct metahash *
@@ -184,13 +188,15 @@ mentries_print(const struct metahash *mhash)
 struct metaentry *
 mentry_create(const char *path)
 {
-	ssize_t lsize, vsize;
-	char *list, *attr;
 	struct stat sbuf;
 	struct passwd *pbuf;
 	struct group *gbuf;
-	int i;
 	struct metaentry *mentry;
+#ifndef __OpenBSD__
+	ssize_t lsize, vsize;
+	char *list, *attr;
+	int i;
+#endif
 
 	if (lstat(path, &sbuf)) {
 		msg(MSG_ERROR, "lstat failed for %s: %s\n",
@@ -225,6 +231,7 @@ mentry_create(const char *path)
 	if (S_ISLNK(mentry->mode))
 		return mentry;
 
+#ifndef __OpenBSD__
 	lsize = listxattr(path, NULL, 0);
 	if (lsize < 0) {
 		/* Perhaps the FS doesn't support xattrs? */
@@ -294,6 +301,7 @@ mentry_create(const char *path)
 	}
 
 	free(list);
+#endif
 	return mentry;
 }
 
@@ -658,6 +666,7 @@ mentries_dump(struct metahash *mhash)
 			       mentry->owner, mentry->group,
 			       date, mentry->mtimensec, zone,
 			       mentry->path, S_ISDIR(mentry->mode) ? "/" : "");
+#ifndef __OpenBSD__
 			for (unsigned i = 0; i < mentry->xattrs; i++) {
 				printf("\t\t\t\t%s%s\t%s=",
 				       mentry->path, S_ISDIR(mentry->mode) ? "/" : "",
@@ -681,6 +690,7 @@ mentries_dump(struct metahash *mhash)
 					printf("\n");
 				}
 			}
+#endif
 		}
 	}
 }

--- a/src/metastore.c
+++ b/src/metastore.c
@@ -23,7 +23,9 @@
 #include <sys/stat.h>
 #include <getopt.h>
 #include <utime.h>
+#ifndef __OpenBSD__
 #include <sys/xattr.h>
+#endif
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -134,7 +136,9 @@ compare_fix(struct metaentry *real, struct metaentry *stored, int cmp)
 	gid_t gid = -1;
 	uid_t uid = -1;
 	struct utimbuf tbuf;
+#ifndef __OpenBSD__
 	unsigned i;
+#endif
 
 	if (!real && !stored) {
 		msg(MSG_ERROR, "%s called with incorrect arguments\n", __func__);
@@ -225,6 +229,7 @@ compare_fix(struct metaentry *real, struct metaentry *stored, int cmp)
 		}
 	}
 
+#ifndef __OpenBSD__
 	if (cmp & DIFF_XATTR) {
 		for (i = 0; i < real->xattrs; i++) {
 			/* Any attrs to remove? */
@@ -253,6 +258,7 @@ compare_fix(struct metaentry *real, struct metaentry *stored, int cmp)
 				    strerror(errno));
 		}
 	}
+#endif
 }
 
 /*


### PR DESCRIPTION
These changes allow metastore to build on OpenBSD 6.0 (the latest
version as of this date).  OpenBSD, as of version 3.8, does not appear
to support extended file attributes.  Hence for OpenBSD, the code
pertaining to this is `#ifdef`ed out here.