### PR TITLE
New --owner and --group for when they can't be read from the system

### DIFF
--- a/src/metaentry.h
+++ b/src/metaentry.h
@@ -54,7 +54,7 @@ struct metahash {
 };
 
 /* Create a metaentry for the file/dir/etc at path */
-struct metaentry *mentry_create(const char *path);
+struct metaentry *mentry_create(const char *path, msettings *st);
 
 /* Recurses opath and adds metadata entries to the metaentry list */
 void mentries_recurse_path(const char *opath, struct metahash **mhash,

--- a/src/settings.h
+++ b/src/settings.h
@@ -23,6 +23,8 @@
 /* Data structure to hold metastore settings */
 struct metasettings {
 	char *metafile;          /* path to the file containing the metadata */
+        char *owner;             /* user-provided owner. */
+        char *group;             /* user-provided group. */
 	bool do_mtime;           /* should mtimes be corrected? */
 	bool do_emptydirs;       /* should empty dirs be recreated? */
 	bool do_removeemptydirs; /* should new empty dirs be removed? */


### PR DESCRIPTION
With these new options, its now possible to use metastore when `getpwuid' and `getgrgid' don't work (for example on a server when the user list isn't present in `/etc/passwd' directly, but hidden somewhere on the network. This problem actually occurred occured for me while trying to use metastore on a server and didn't allow me to use it. So it would probably be very useful for other users in such scenarios also.

I just haven't added the man-page entry for these options because I don't have any experience in them. If you feel its good to merge with master, could you please add man page entries for it too?